### PR TITLE
 Allow `postfix` to be used as identifier in pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
 - ./dogFooding.sh -diagnostics-only
 - ./lint.sh
 after_success:
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./runXcodeTest.sh; bash <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov) -X xcodeplist; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./runXcodeTest.sh; bash <(curl -s https://codecov.io/bash); fi

--- a/Sources/Parser/Parser+Pattern.swift
+++ b/Sources/Parser/Parser+Pattern.swift
@@ -128,7 +128,7 @@ extension Parser {
     case .identifier(let id):
       return try parseIdentifierHeadedPattern(
         id, config: config, startRange: lookedRange)
-    case .Any, .Self, .get, .set, .left, .right, .open, .prefix:
+    case .Any, .Self, .get, .set, .left, .right, .open, .prefix, .postfix:
       guard let idHead = patternHead.namedIdentifier else {
         throw _raiseFatal(.expectedPattern)
       }

--- a/Tests/ParserTests/Pattern/ParserIdentifierPatternTests.swift
+++ b/Tests/ParserTests/Pattern/ParserIdentifierPatternTests.swift
@@ -41,6 +41,7 @@ class ParserIdentifierPatternTests: XCTestCase {
       "right",
       "open",
       "prefix",
+      "postfix",
     ]
     for keyword in keywords {
       parsePatternAndTest(keyword, keyword, testClosure: { pttrn in


### PR DESCRIPTION
Fixes #62.