### PR TITLE
Fix issue where swift-ast will not parse *.swiftinterface files

### DIFF
--- a/.swiftpm/xcode/xcuserdata/travisprescott.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/.swiftpm/xcode/xcuserdata/travisprescott.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>SwiftAST+Tooling.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>3</integer>
+		</dict>
+		<key>SwiftAST.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+		<key>swift-ast-Package.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+		<key>swift-ast.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>2</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sources/AST/AsyncKind.swift
+++ b/Sources/AST/AsyncKind.swift
@@ -1,0 +1,31 @@
+/*
+   Copyright 2021 Travis Prescott
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+public enum AsyncKind {
+  case notasync
+  case async
+}
+
+extension AsyncKind : ASTTextRepresentable {
+  public var textDescription: String {
+    switch self {
+    case .notasync:
+      return ""
+    case .async:
+      return "async"
+    }
+  }
+}

--- a/Sources/AST/Declaration/Function/FunctionSignature.swift
+++ b/Sources/AST/Declaration/Function/FunctionSignature.swift
@@ -19,16 +19,19 @@ public struct FunctionSignature {
     public let externalName: Identifier?
     public let localName: Identifier
     public let typeAnnotation: TypeAnnotation
+    public let attributes: Attributes?
     public let defaultArgumentClause: Expression?
     public let isVarargs: Bool
 
     public init(
       externalName: Identifier? = nil,
       localName: Identifier,
+      attributes: Attributes?,
       typeAnnotation: TypeAnnotation
     ) {
       self.externalName = externalName
       self.localName = localName
+      self.attributes = attributes
       self.typeAnnotation = typeAnnotation
       self.defaultArgumentClause = nil
       self.isVarargs = false
@@ -37,11 +40,13 @@ public struct FunctionSignature {
     public init(
       externalName: Identifier? = nil,
       localName: Identifier,
+      attributes: Attributes?,
       typeAnnotation: TypeAnnotation,
       isVarargs: Bool = false
     ) {
       self.externalName = externalName
       self.localName = localName
+      self.attributes = attributes
       self.typeAnnotation = typeAnnotation
       self.defaultArgumentClause = nil
       self.isVarargs = isVarargs
@@ -50,11 +55,13 @@ public struct FunctionSignature {
     public init(
       externalName: Identifier? = nil,
       localName: Identifier,
+      attributes: Attributes?,
       typeAnnotation: TypeAnnotation,
       defaultArgumentClause: Expression? = nil
     ) {
       self.externalName = externalName
       self.localName = localName
+      self.attributes = attributes
       self.typeAnnotation = typeAnnotation
       self.defaultArgumentClause = defaultArgumentClause
       self.isVarargs = false

--- a/Sources/AST/Declaration/Function/FunctionSignature.swift
+++ b/Sources/AST/Declaration/Function/FunctionSignature.swift
@@ -26,7 +26,7 @@ public struct FunctionSignature {
     public init(
       externalName: Identifier? = nil,
       localName: Identifier,
-      attributes: Attributes?,
+      attributes: Attributes? = nil,
       typeAnnotation: TypeAnnotation
     ) {
       self.externalName = externalName
@@ -55,7 +55,7 @@ public struct FunctionSignature {
     public init(
       externalName: Identifier? = nil,
       localName: Identifier,
-      attributes: Attributes?,
+      attributes: Attributes? = nil,
       typeAnnotation: TypeAnnotation,
       defaultArgumentClause: Expression? = nil
     ) {

--- a/Sources/AST/Declaration/Function/FunctionSignature.swift
+++ b/Sources/AST/Declaration/Function/FunctionSignature.swift
@@ -62,15 +62,18 @@ public struct FunctionSignature {
   }
 
   public let parameterList: [Parameter]
+  public let asyncKind: AsyncKind
   public let throwsKind: ThrowsKind
   public let result: FunctionResult?
 
   public init(
     parameterList: [Parameter] = [],
+    asyncKind: AsyncKind = .notasync,
     throwsKind: ThrowsKind = .nothrowing,
     result: FunctionResult? = nil
   ) {
     self.parameterList = parameterList
+    self.asyncKind = asyncKind
     self.throwsKind = throwsKind
     self.result = result
   }
@@ -93,9 +96,11 @@ extension FunctionSignature : ASTTextRepresentable {
   public var textDescription: String {
     let parameterText =
       ["(\(parameterList.map({ $0.textDescription }).joined(separator: ", ")))"]
+    let asyncKindText =
+      asyncKind.textDescription.isEmpty ? [] : [asyncKind.textDescription]
     let throwsKindText =
       throwsKind.textDescription.isEmpty ? [] : [throwsKind.textDescription]
     let resultText = result.map({ [$0.textDescription] }) ?? []
-    return (parameterText + throwsKindText + resultText).joined(separator: " ")
+    return (parameterText + asyncKindText + throwsKindText + resultText).joined(separator: " ")
   }
 }

--- a/Sources/AST/Pattern/SelfPattern.swift
+++ b/Sources/AST/Pattern/SelfPattern.swift
@@ -1,0 +1,28 @@
+/*
+   Copyright 2016-2017 Ryuichi Intellectual Property and the Yanagiba project contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+public class SelfPattern : PatternBase {
+
+  override public init() {
+    super.init()
+  }
+
+  // MARK: - ASTTextRepresentable
+
+  override public var textDescription: String {
+    return "self"
+  }
+}

--- a/Sources/AST/Type/TypeIdentifier.swift
+++ b/Sources/AST/Type/TypeIdentifier.swift
@@ -28,9 +28,11 @@ public class TypeIdentifier : TypeBase {
   }
 
   public let names: [TypeName]
+  public let attributes: Attributes?
 
-  public init(names: [TypeName] = []) {
+  public init(names: [TypeName] = [], attributes: Attributes? = nil) {
     self.names = names
+    self.attributes = attributes
   }
 
   // MARK: - ASTTextRepresentable

--- a/Sources/Lexer/Lexer+Identifier.swift
+++ b/Sources/Lexer/Lexer+Identifier.swift
@@ -88,6 +88,7 @@ fileprivate extension Role {
 fileprivate let keywordMapping: [String: Token.Kind] = [
   "as": .as,
   "associativity": .associativity,
+  "async": .async,
   "break": .break,
   "catch": .catch,
   "case": .case,

--- a/Sources/Lexer/Token.swift
+++ b/Sources/Lexer/Token.swift
@@ -54,7 +54,7 @@ public struct Token {
     case `internal`, `private`, `public`, `fileprivate`, `open`
     // keywords
     case `Any`, `Self`
-    case `as`, associativity, `break`, `catch`, `case`, `class`, `continue`
+    case `as`, associativity, `async`, `break`, `catch`, `case`, `class`, `continue`
     case `default`, `defer`, `deinit`, didSet, `do`, `enum`
     case `extension`, `else`, `fallthrough`, `for`, `func`, get, `guard`, `if`
     case `import`, `in`, indirect, infix, `init`, `inout`, `is`, `let`

--- a/Sources/Lexer/TokenKind+Equatable.swift
+++ b/Sources/Lexer/TokenKind+Equatable.swift
@@ -75,6 +75,7 @@ extension Token.Kind {
       (.open, .open),
       (.as, .as),
       (.associativity, .associativity),
+      (.async, .async),
       (.break, .break),
       (.catch, .catch),
       (.case, .case),

--- a/Sources/Lexer/TokenKind+Naming.swift
+++ b/Sources/Lexer/TokenKind+Naming.swift
@@ -43,6 +43,8 @@ public extension Token.Kind /* named identifier */ {
       return .name("as")
     case .associativity:
       return .name("associativity")
+    case .async:
+      return .name("async")
     case .break:
       return .name("break")
     case .catch:

--- a/Sources/Parser/Parser+Common.swift
+++ b/Sources/Parser/Parser+Common.swift
@@ -27,6 +27,16 @@ extension Parser {
     return FunctionResult(attributes: attrs, type: type)
   }
 
+  func parseAsyncKind() -> (AsyncKind, SourceLocation?) {
+    let endLocation = getEndLocation()
+    switch _lexer.read([.async]) {
+    case .async:
+      return (.async, endLocation)
+    default:
+      return (.notasync, nil)
+    }
+  }
+
   func parseThrowsKind() -> (ThrowsKind, SourceLocation?) {
     let endLocation = getEndLocation()
     switch _lexer.read([.throws, .rethrows]) {

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -1000,12 +1000,15 @@ extension Parser {
 
     func parseSignature() throws -> (FunctionSignature, SourceLocation) {
       let (params, paramsSrcRange) = try parseParameterClause()
+      let (asyncKind, asyncEndLocation) = parseAsyncKind()
       let (throwsKind, throwsEndLocation) = parseThrowsKind()
       let result = try parseFunctionResult()
 
-      let funcSign = FunctionSignature(parameterList: params, throwsKind: throwsKind, result: result)
+      let funcSign = FunctionSignature(parameterList: params, asyncKind: asyncKind, throwsKind: throwsKind, result: result)
       if let resultEndLocation = result?.type.sourceRange.end {
         return (funcSign, resultEndLocation)
+      } else if let asyncEndLocation = asyncEndLocation {
+          return (funcSign, asyncEndLocation)
       } else if let throwsEndLocation = throwsEndLocation {
         return (funcSign, throwsEndLocation)
       } else {

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -49,7 +49,8 @@ extension Parser {
       .import, .let, .var, .typealias, .func, .enum, .indirect, .struct,
       .`init`, .deinit, .extension, .subscript, .operator, .protocol
     ]
-    switch _lexer.read(declHeadTokens) {
+    let value = _lexer.read(declHeadTokens)
+    switch value {
     case .import:
       return try parseImportDeclaration(
         withAttributes: attrs, startLocation: startLocation)

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -568,7 +568,7 @@ extension Parser {
   private func parseDeinitializerDeclaration(
     withAttributes attrs: Attributes, startLocation: SourceLocation
   ) throws -> DeinitializerDeclaration {
-    let body = try parseCodeBlock()
+    let body = (try? parseCodeBlock()) ?? CodeBlock()
     let deinitDecl = DeinitializerDeclaration(attributes: attrs, body: body)
     deinitDecl.setSourceRange(startLocation, body.sourceRange.end)
     return deinitDecl

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -902,6 +902,7 @@ extension Parser {
     func parseParameter() throws -> FunctionSignature.Parameter {
       var externalName: Identifier?
       var internalName: Identifier?
+      let attrs = try? parseAttributes()
       if _lexer.match(.underscore) {
         if let name = readNamedIdentifier() {
           externalName = .wildcard
@@ -910,8 +911,6 @@ extension Parser {
           externalName = .wildcard
           internalName = .name("")
         }
-      } else if let attrs = try? parseAttributes() {
-          let test = "best"
       } else if let firstName = readNamedIdentifier() {
         if let secondName = readNamedIdentifierOrWildcard() {
           externalName = firstName
@@ -935,6 +934,7 @@ extension Parser {
         return FunctionSignature.Parameter(
           externalName: externalName,
           localName: localName,
+          attributes: attrs,
           typeAnnotation: typeAnnotation,
           defaultArgumentClause: defaultExpr)
       case .postfixOperator("..."):
@@ -942,12 +942,14 @@ extension Parser {
         return FunctionSignature.Parameter(
           externalName: externalName,
           localName: localName,
+          attributes: attrs,
           typeAnnotation: typeAnnotation,
           isVarargs: true)
       default:
         return FunctionSignature.Parameter(
           externalName: externalName,
           localName: localName,
+          attributes: attrs,
           typeAnnotation: typeAnnotation)
       }
     }

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -910,6 +910,8 @@ extension Parser {
           externalName = .wildcard
           internalName = .name("")
         }
+      } else if let attrs = try? parseAttributes() {
+          let test = "best"
       } else if let firstName = readNamedIdentifier() {
         if let secondName = readNamedIdentifierOrWildcard() {
           externalName = firstName

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -28,7 +28,7 @@ extension Parser {
 
   func parseCodeBlock() throws -> CodeBlock {
     let startLocation = getStartLocation()
-    try match(.leftBrace, orFatal: .leftBraceExpected("code block"))
+    try match(.leftBrace, orError: .leftBraceExpected("code block"))
     let stmts = try parseStatements()
     let endLocation = getEndLocation()
     try match(.rightBrace, orFatal: .rightBraceExpected("code block"))
@@ -593,8 +593,7 @@ extension Parser {
     let (params, _) = try parseParameterClause()
     let (throwsKind, _) = parseThrowsKind()
     let genericWhereClause = try parseGenericWhereClause()
-    let body = forProtocolMember ? CodeBlock() : try parseCodeBlock()
-
+    let body = forProtocolMember ? CodeBlock() : (try? parseCodeBlock()) ?? CodeBlock()
     let initDecl = InitializerDeclaration(
       attributes: attrs,
       modifiers: modifiers,

--- a/Sources/Parser/Parser+Diagnostic.swift
+++ b/Sources/Parser/Parser+Diagnostic.swift
@@ -34,7 +34,7 @@ extension Parser {
   }
 }
 
-public enum ParserErrorKind : DiagnosticKind {
+public enum ParserErrorKind : DiagnosticKind, Error {
   case dummy
 
   case leftBraceExpected(String)

--- a/Sources/Parser/Parser+Lexing.swift
+++ b/Sources/Parser/Parser+Lexing.swift
@@ -24,7 +24,10 @@ extension Parser {
   }
 
   func assert(_ cond: Bool, orError error: ParserErrorKind) throws {
-    if !cond { try _raiseError(error) }
+    if !cond {
+        try _raiseError(error)
+        throw error
+    }
   }
 
   func match(_ kinds: [Token.Kind], exactMatch: Bool = false, orFatal fatalError: ParserErrorKind) throws {
@@ -33,6 +36,14 @@ extension Parser {
 
   func match(_ kind: Token.Kind, exactMatch: Bool = false, orFatal fatalError: ParserErrorKind) throws {
     try match([kind], exactMatch: exactMatch, orFatal: fatalError)
+  }
+
+  func match(_ kinds: [Token.Kind], exactMatch: Bool = false, orError error: ParserErrorKind) throws {
+    try assert(_lexer.match(kinds, exactMatch: exactMatch), orError: error)
+  }
+
+  func match(_ kind: Token.Kind, exactMatch: Bool = false, orError error: ParserErrorKind) throws {
+    try match([kind], exactMatch: exactMatch, orError: error)
   }
 
   func readIdentifier(_ id: String, orFatal fatalError: ParserErrorKind) throws {

--- a/Sources/Parser/Parser+Pattern.swift
+++ b/Sources/Parser/Parser+Pattern.swift
@@ -129,6 +129,8 @@ extension Parser {
       return try parseIdentifierHeadedPattern(idHead, config: config, startRange: lookedRange)
     case .leftParen:
       return try parseTuplePattern(config: config, startLocation: lookedRange.start)
+    case .self:
+      return try parseSelfPattern(startRange: lookedRange)
     default:
       if config.forPatternMatching {
         let updatedConfig = ParserExpressionConfig(parseTrailingClosure: config.parseTrailingClosure)
@@ -153,6 +155,14 @@ extension Parser {
     let wildcardPttrn = WildcardPattern(typeAnnotation: typeAnnotation)
     wildcardPttrn.setSourceRange(startRange.start, endLocation)
     return wildcardPttrn
+  }
+
+  private func parseSelfPattern(startRange: SourceRange) -> Pattern {
+    let endLocation = startRange.end
+    _lexer.advance()
+    let pattern = SelfPattern()
+    pattern.setSourceRange(startRange.start, endLocation)
+    return pattern
   }
 
   private func parseIdentifierHeadedPattern(

--- a/Sources/Parser/Parser+Statement.swift
+++ b/Sources/Parser/Parser+Statement.swift
@@ -34,7 +34,7 @@ extension Parser {
   func parseStatement() throws -> Statement { // swift-lint:suppress(high_cyclomatic_complexity,high_ncss)
     let stmt: Statement
     let lookedRange = getLookedRange()
-    switch _lexer.read([
+    let value = _lexer.read([
       .for, .while, .repeat, // loop
       .if, .guard, .switch, // branch
       // identifier as labelel statement
@@ -45,7 +45,8 @@ extension Parser {
       .hash,
       // declaration statement
       // expression statement
-    ]) {
+    ])
+    switch value {
     case .for:
       stmt = try parseForInStatement(startLocation: lookedRange.start)
     case .while:

--- a/Sources/Parser/Parser+Type.swift
+++ b/Sources/Parser/Parser+Type.swift
@@ -90,7 +90,7 @@ extension Parser {
     }
   }
 
-  func parseIdentifierType(_ headId: Identifier, _ startRange: SourceRange) throws -> TypeIdentifier {
+    func parseIdentifierType(_ headId: Identifier, _ startRange: SourceRange, attributes: Attributes? = nil) throws -> TypeIdentifier {
     var endLocation = startRange.end
     let headGenericArgumentClause = parseGenericArgumentClause()
     if let headGenericArg = headGenericArgumentClause {
@@ -112,7 +112,7 @@ extension Parser {
       names.append(typeIdentifierName)
     }
 
-    let idType = TypeIdentifier(names: names)
+        let idType = TypeIdentifier(names: names, attributes: attributes)
     idType.setSourceRange(startRange.start, endLocation)
     return idType
   }
@@ -386,11 +386,12 @@ extension Parser {
     }
     var types = [TypeIdentifier]()
     repeat {
+      let attrs = try? parseAttributes()
       let typeSourceRange = getLookedRange()
       if _lexer.match(.class) {
         throw _raiseFatal(.lateClassRequirement)
       } else if let idHead = readNamedIdentifier() {
-        let type = try parseIdentifierType(idHead, typeSourceRange)
+        let type = try parseIdentifierType(idHead, typeSourceRange, attributes: attrs)
         types.append(type)
       } else {
         throw _raiseFatal(.expectedTypeRestriction)

--- a/Sources/Sema/SequenceExpressionFolding.swift
+++ b/Sources/Sema/SequenceExpressionFolding.swift
@@ -90,6 +90,7 @@ private class FoldingVisitor : ASTVisitor {
     return FunctionSignature.Parameter(
       externalName: p.externalName,
       localName: p.localName,
+      attributes: p.attributes,
       typeAnnotation: p.typeAnnotation,
       defaultArgumentClause: foldedExpr)
   }

--- a/Tests/ParserTests/Declaration/ParserFunctionDeclarationTests.swift
+++ b/Tests/ParserTests/Declaration/ParserFunctionDeclarationTests.swift
@@ -428,6 +428,32 @@ class ParserFunctionDeclarationTests: XCTestCase {
     })
   }
 
+  func testAsyncFunction() {
+    parseDeclarationAndTest(
+      "func foo(bar: Bar) async",
+      "func foo(bar: Bar) async",
+      testClosure: { decl in
+      guard let funcDecl = decl as? FunctionDeclaration else {
+        XCTFail("Failed in getting a function declaration.")
+        return
+      }
+
+      XCTAssertTrue(funcDecl.attributes.isEmpty)
+      XCTAssertTrue(funcDecl.modifiers.isEmpty)
+      XCTAssertEqual(funcDecl.name.textDescription, "foo")
+      XCTAssertNil(funcDecl.genericParameterClause)
+
+      XCTAssertEqual(funcDecl.signature.parameterList.count, 1)
+      XCTAssertEqual(funcDecl.signature.parameterList[0].textDescription, "bar: Bar")
+      XCTAssertEqual(funcDecl.signature.asyncKind, .async)
+      XCTAssertNil(funcDecl.signature.result)
+      XCTAssertEqual(funcDecl.signature.textDescription, "(bar: Bar) async")
+
+      XCTAssertNil(funcDecl.genericWhereClause)
+      XCTAssertNil(funcDecl.body)
+    })
+  }
+
   func testFunctionThatThrows() {
     parseDeclarationAndTest(
       "func foo(bar: Bar) throws",


### PR DESCRIPTION
Fixes issue #106.

It seems like the only thing blocking swift-ast from working with *.swiftinterface files was a few statement in initializer parsing that require a body. With a few changes I was able to unblock myself.

It would probably be best to only allow this behavior if you confirm that the file being targeted is *.swiftinterface, but I figured I would share what worked for me. 