### PR TITLE
Add support Swift 6 - rename Expression to ASTExpression

### DIFF
--- a/Sources/AST/ASTExpression.swift
+++ b/Sources/AST/ASTExpression.swift
@@ -14,16 +14,16 @@
    limitations under the License.
 */
 
-public protocol Expression : Statement {
+public protocol ASTExpression : Statement {
 }
 
-public protocol BinaryExpression : Expression {
+public protocol BinaryExpression : ASTExpression {
 }
 
-public protocol PrefixExpression :  Expression {
+public protocol PrefixExpression :  ASTExpression {
 }
 
-public protocol PostfixExpression : Expression {
+public protocol PostfixExpression : ASTExpression {
 }
 
 public protocol PrimaryExpression : PostfixExpression {

--- a/Sources/AST/ASTVisitor+Traversal.swift
+++ b/Sources/AST/ASTVisitor+Traversal.swift
@@ -294,7 +294,7 @@ extension ASTVisitor {
     switch statement {
     case let decl as Declaration:
       return try traverse(decl)
-    case let expr as Expression:
+    case let expr as ASTExpression:
       return try traverse(expr)
     case let stmt as BreakStatement:
       return try traverse(stmt)
@@ -481,7 +481,7 @@ extension ASTVisitor {
 
   // Expressions
 
-  public func traverse(_ expression: Expression) throws -> Bool {/*
+  public func traverse(_ expression: ASTExpression) throws -> Bool {/*
     swift-lint:rule_configure(CYCLOMATIC_COMPLEXITY=28)
     swift-lint:suppress(high_ncss)
     */

--- a/Sources/AST/Declaration/Function/FunctionSignature.swift
+++ b/Sources/AST/Declaration/Function/FunctionSignature.swift
@@ -19,7 +19,7 @@ public struct FunctionSignature {
     public let externalName: Identifier?
     public let localName: Identifier
     public let typeAnnotation: TypeAnnotation
-    public let defaultArgumentClause: Expression?
+    public let defaultArgumentClause: ASTExpression?
     public let isVarargs: Bool
 
     public init(
@@ -51,7 +51,7 @@ public struct FunctionSignature {
       externalName: Identifier? = nil,
       localName: Identifier,
       typeAnnotation: TypeAnnotation,
-      defaultArgumentClause: Expression? = nil
+      defaultArgumentClause: ASTExpression? = nil
     ) {
       self.externalName = externalName
       self.localName = localName

--- a/Sources/AST/Declaration/Initializer/PatternInitializer.swift
+++ b/Sources/AST/Declaration/Initializer/PatternInitializer.swift
@@ -18,9 +18,9 @@ import Source
 
 public struct PatternInitializer {
   public let pattern: Pattern
-  public let initializerExpression: Expression?
+  public let initializerExpression: ASTExpression?
 
-  public init(pattern: Pattern, initializerExpression: Expression? = nil) {
+  public init(pattern: Pattern, initializerExpression: ASTExpression? = nil) {
     self.pattern = pattern
     self.initializerExpression = initializerExpression
   }

--- a/Sources/AST/Declaration/VariableDeclaration.swift
+++ b/Sources/AST/Declaration/VariableDeclaration.swift
@@ -22,7 +22,7 @@ public class VariableDeclaration : ASTNode, Declaration {
     case getterSetterKeywordBlock(
       Identifier, TypeAnnotation, GetterSetterKeywordBlock)
     case willSetDidSetBlock(
-      Identifier, TypeAnnotation?, Expression?, WillSetDidSetBlock)
+      Identifier, TypeAnnotation?, ASTExpression?, WillSetDidSetBlock)
   }
   public let attributes: Attributes
   public let modifiers: DeclarationModifiers
@@ -88,7 +88,7 @@ public class VariableDeclaration : ASTNode, Declaration {
     attributes: Attributes = [],
     modifiers: DeclarationModifiers = [],
     variableName: Identifier,
-    initializer: Expression,
+    initializer: ASTExpression,
     willSetDidSetBlock: WillSetDidSetBlock
   ) {
     self.init(
@@ -103,7 +103,7 @@ public class VariableDeclaration : ASTNode, Declaration {
     modifiers: DeclarationModifiers = [],
     variableName: Identifier,
     typeAnnotation: TypeAnnotation,
-    initializer: Expression? = nil,
+    initializer: ASTExpression? = nil,
     willSetDidSetBlock: WillSetDidSetBlock
   ) {
     self.init(attributes: attributes,

--- a/Sources/AST/Expression/AssignmentOperatorExpression.swift
+++ b/Sources/AST/Expression/AssignmentOperatorExpression.swift
@@ -15,10 +15,10 @@
 */
 
 public class AssignmentOperatorExpression : ASTNode, BinaryExpression {
-  public let leftExpression: Expression
-  public let rightExpression: Expression
+  public let leftExpression: ASTExpression
+  public let rightExpression: ASTExpression
 
-  public init(leftExpression: Expression, rightExpression: Expression) {
+  public init(leftExpression: ASTExpression, rightExpression: ASTExpression) {
     self.leftExpression = leftExpression
     self.rightExpression = rightExpression
   }

--- a/Sources/AST/Expression/BinaryOperatorExpression.swift
+++ b/Sources/AST/Expression/BinaryOperatorExpression.swift
@@ -16,13 +16,13 @@
 
 public class BinaryOperatorExpression : ASTNode, BinaryExpression {
   public let binaryOperator: Operator
-  public let leftExpression: Expression
-  public let rightExpression: Expression
+  public let leftExpression: ASTExpression
+  public let rightExpression: ASTExpression
 
   public init(
     binaryOperator: Operator,
-    leftExpression: Expression,
-    rightExpression: Expression
+    leftExpression: ASTExpression,
+    rightExpression: ASTExpression
   ) {
     self.binaryOperator = binaryOperator
     self.leftExpression = leftExpression

--- a/Sources/AST/Expression/ClosureExpression.swift
+++ b/Sources/AST/Expression/ClosureExpression.swift
@@ -25,9 +25,9 @@ public class ClosureExpression : ASTNode, PrimaryExpression {
       }
 
       public let specifier: Specifier?
-      public let expression: Expression
+      public let expression: ASTExpression
 
-      public init(specifier: Specifier? = nil, expression: Expression) {
+      public init(specifier: Specifier? = nil, expression: ASTExpression) {
         self.specifier = specifier
         self.expression = expression
       }

--- a/Sources/AST/Expression/FunctionCallExpression.swift
+++ b/Sources/AST/Expression/FunctionCallExpression.swift
@@ -16,10 +16,10 @@
 
 public class FunctionCallExpression : ASTNode, PostfixExpression {
   public enum Argument {
-    case expression(Expression)
-    case namedExpression(Identifier, Expression)
-    case memoryReference(Expression)
-    case namedMemoryReference(Identifier, Expression)
+    case expression(ASTExpression)
+    case namedExpression(Identifier, ASTExpression)
+    case memoryReference(ASTExpression)
+    case namedMemoryReference(Identifier, ASTExpression)
     case `operator`(Operator)
     case namedOperator(Identifier, Operator)
   }

--- a/Sources/AST/Expression/KeyPathStringExpression.swift
+++ b/Sources/AST/Expression/KeyPathStringExpression.swift
@@ -15,9 +15,9 @@
 */
 
 public class KeyPathStringExpression : ASTNode, PrimaryExpression {
-  public let expression: Expression
+  public let expression: ASTExpression
 
-  public init(expression: Expression) {
+  public init(expression: ASTExpression) {
     self.expression = expression
   }
 

--- a/Sources/AST/Expression/LiteralExpression.swift
+++ b/Sources/AST/Expression/LiteralExpression.swift
@@ -15,10 +15,10 @@
 */
 
 public class DictionaryEntry {
-  public let key: Expression
-  public let value: Expression
+  public let key: ASTExpression
+  public let value: ASTExpression
 
-  public init(key: Expression, value: Expression) {
+  public init(key: ASTExpression, value: ASTExpression) {
     self.key = key
     self.value = value
   }
@@ -31,9 +31,9 @@ extension DictionaryEntry : ASTTextRepresentable {
 }
 
 public enum PlaygroundLiteral {
-  case color(Expression, Expression, Expression, Expression)
-  case file(Expression)
-  case image(Expression)
+  case color(ASTExpression, ASTExpression, ASTExpression, ASTExpression)
+  case file(ASTExpression)
+  case image(ASTExpression)
 }
 
 extension PlaygroundLiteral : ASTTextRepresentable {
@@ -60,8 +60,8 @@ public class LiteralExpression : ASTNode, PrimaryExpression {
     case integer(Int, String)
     case floatingPoint(Double, String)
     case staticString(String, String)
-    case interpolatedString([Expression], String)
-    case array([Expression])
+    case interpolatedString([ASTExpression], String)
+    case array([ASTExpression])
     case dictionary([DictionaryEntry])
     case playground(PlaygroundLiteral)
   }

--- a/Sources/AST/Expression/ParenthesizedExpression.swift
+++ b/Sources/AST/Expression/ParenthesizedExpression.swift
@@ -15,15 +15,15 @@
 */
 
 public class ParenthesizedExpression : ASTNode, PrimaryExpression {
-  public private(set) var expression: Expression
+  public private(set) var expression: ASTExpression
 
-  public init(expression: Expression) {
+  public init(expression: ASTExpression) {
     self.expression = expression
   }
 
   // MARK: - Node Mutations
 
-  public func reset(with newExpression: Expression) {
+  public func reset(with newExpression: ASTExpression) {
     expression = newExpression
   }
 

--- a/Sources/AST/Expression/SelectorExpression.swift
+++ b/Sources/AST/Expression/SelectorExpression.swift
@@ -16,9 +16,9 @@
 
 public class SelectorExpression : ASTNode, PrimaryExpression {
   public enum Kind {
-    case selector(Expression)
-    case getter(Expression)
-    case setter(Expression)
+    case selector(ASTExpression)
+    case getter(ASTExpression)
+    case setter(ASTExpression)
 
     // Note: I don't see any defined expression that I can use,
     // so store this special type of expression inside selector-expression for now

--- a/Sources/AST/Expression/SequenceExpression.swift
+++ b/Sources/AST/Expression/SequenceExpression.swift
@@ -31,10 +31,10 @@ import Source
  */
 public class SequenceExpression : ASTNode, BinaryExpression {
   public enum Element {
-    case expression(Expression)
+    case expression(ASTExpression)
     case assignmentOperator
     case binaryOperator(Operator)
-    case ternaryConditionalOperator(Expression)
+    case ternaryConditionalOperator(ASTExpression)
     case typeCheck(Type)
     case typeCast(Type)
     case typeConditionalCast(Type)

--- a/Sources/AST/Expression/Subscript/SubscriptArgument.swift
+++ b/Sources/AST/Expression/Subscript/SubscriptArgument.swift
@@ -16,9 +16,9 @@
 
 public struct SubscriptArgument {
   public let identifier: Identifier?
-  public let expression: Expression
+  public let expression: ASTExpression
 
-  public init(identifier: Identifier? = nil, expression: Expression) {
+  public init(identifier: Identifier? = nil, expression: ASTExpression) {
     self.identifier = identifier
     self.expression = expression
   }

--- a/Sources/AST/Expression/TernaryConditionalOperatorExpression.swift
+++ b/Sources/AST/Expression/TernaryConditionalOperatorExpression.swift
@@ -15,14 +15,14 @@
 */
 
 public class TernaryConditionalOperatorExpression : ASTNode, BinaryExpression {
-  public let conditionExpression: Expression
-  public let trueExpression: Expression
-  public let falseExpression: Expression
+  public let conditionExpression: ASTExpression
+  public let trueExpression: ASTExpression
+  public let falseExpression: ASTExpression
 
   public init(
-    conditionExpression: Expression,
-    trueExpression: Expression,
-    falseExpression: Expression
+    conditionExpression: ASTExpression,
+    trueExpression: ASTExpression,
+    falseExpression: ASTExpression
   ) {
     self.conditionExpression = conditionExpression
     self.trueExpression = trueExpression

--- a/Sources/AST/Expression/TryOperatorExpression.swift
+++ b/Sources/AST/Expression/TryOperatorExpression.swift
@@ -14,11 +14,11 @@
    limitations under the License.
 */
 
-public class TryOperatorExpression : ASTNode, Expression {
+public class TryOperatorExpression : ASTNode, ASTExpression {
   public enum Kind {
-    case `try`(Expression)
-    case forced(Expression)
-    case optional(Expression)
+    case `try`(ASTExpression)
+    case forced(ASTExpression)
+    case optional(ASTExpression)
   }
 
   public private(set) var kind: Kind

--- a/Sources/AST/Expression/TupleExpression.swift
+++ b/Sources/AST/Expression/TupleExpression.swift
@@ -17,14 +17,14 @@
 public class TupleExpression : ASTNode, PrimaryExpression {
   public struct Element {
     public let identifier: Identifier?
-    public let expression: Expression
+    public let expression: ASTExpression
 
-    public init(identifier: Identifier?, expression: Expression) {
+    public init(identifier: Identifier?, expression: ASTExpression) {
       self.identifier = identifier
       self.expression = expression
     }
 
-    public init(expression: Expression) {
+    public init(expression: ASTExpression) {
       self.init(identifier: nil, expression: expression)
     }
   }

--- a/Sources/AST/Expression/TypeCastingOperatorExpression.swift
+++ b/Sources/AST/Expression/TypeCastingOperatorExpression.swift
@@ -16,10 +16,10 @@
 
 public class TypeCastingOperatorExpression : ASTNode, BinaryExpression {
   public enum Kind {
-    case check(Expression, Type) // is
-    case cast(Expression, Type) // as
-    case conditionalCast(Expression, Type) // as?
-    case forcedCast(Expression, Type) // as!
+    case check(ASTExpression, Type) // is
+    case cast(ASTExpression, Type) // as
+    case conditionalCast(ASTExpression, Type) // as?
+    case forcedCast(ASTExpression, Type) // as!
   }
 
   public let kind: Kind

--- a/Sources/AST/ExpressionList.swift
+++ b/Sources/AST/ExpressionList.swift
@@ -14,9 +14,9 @@
    limitations under the License.
 */
 
-public typealias ExpressionList = [Expression]
+public typealias ExpressionList = [ASTExpression]
 
-extension Collection where Iterator.Element == Expression {
+extension Collection where Iterator.Element == ASTExpression {
   public var textDescription: String {
     return self.map({ $0.textDescription }).joined(separator: ", ")
   }

--- a/Sources/AST/Pattern/ExpressionPattern.swift
+++ b/Sources/AST/Pattern/ExpressionPattern.swift
@@ -17,9 +17,9 @@
 import Source
 
 public class ExpressionPattern : PatternBase {
-  public let expression: Expression
+  public let expression: ASTExpression
 
-  public init(expression: Expression) {
+  public init(expression: ASTExpression) {
     self.expression = expression
   }
 

--- a/Sources/AST/Statement/Condition/Condition.swift
+++ b/Sources/AST/Statement/Condition/Condition.swift
@@ -15,11 +15,11 @@
 */
 
 public enum Condition {
-  case expression(Expression)
+  case expression(ASTExpression)
   case availability(AvailabilityCondition)
-  case `case`(Pattern, Expression) // case condition
-  case `let`(Pattern, Expression) // optional-binding condition
-  case `var`(Pattern, Expression) // optional-binding condition
+  case `case`(Pattern, ASTExpression) // case condition
+  case `let`(Pattern, ASTExpression) // optional-binding condition
+  case `var`(Pattern, ASTExpression) // optional-binding condition
 }
 
 extension Condition : ASTTextRepresentable {

--- a/Sources/AST/Statement/DoStatement.swift
+++ b/Sources/AST/Statement/DoStatement.swift
@@ -18,12 +18,12 @@
 public class DoStatement : ASTNode, Statement {
   public struct CatchClause {
     public let pattern: Pattern?
-    public let whereExpression: Expression?
+    public let whereExpression: ASTExpression?
     public let codeBlock: CodeBlock
 
     public init(
       pattern: Pattern? = nil,
-      whereExpression: Expression? = nil,
+      whereExpression: ASTExpression? = nil,
       codeBlock: CodeBlock
     ) {
       self.pattern = pattern

--- a/Sources/AST/Statement/ForInStatement.swift
+++ b/Sources/AST/Statement/ForInStatement.swift
@@ -19,17 +19,17 @@ public class ForInStatement : ASTNode, Statement {
                         // but I will leave it as it is, and decide this later
     public let isCaseMatching: Bool
     public let matchingPattern: Pattern
-    public let whereClause: Expression?
+    public let whereClause: ASTExpression?
   }
   public private(set) var item: Item
-  public private(set) var collection: Expression
+  public private(set) var collection: ASTExpression
   public let codeBlock: CodeBlock
 
   public init(
     isCaseMatching: Bool = false,
     matchingPattern: Pattern,
-    collection: Expression,
-    whereClause: Expression? = nil,
+    collection: ASTExpression,
+    whereClause: ASTExpression? = nil,
     codeBlock: CodeBlock
   ) {
     self.item = Item(isCaseMatching: isCaseMatching,
@@ -40,11 +40,11 @@ public class ForInStatement : ASTNode, Statement {
 
   // MARK: - Node Mutations
 
-  public func replaceCollection(with expr: Expression) {
+  public func replaceCollection(with expr: ASTExpression) {
     collection = expr
   }
 
-  public func replaceWhereClause(with expr: Expression) {
+  public func replaceWhereClause(with expr: ASTExpression) {
     item = Item(isCaseMatching: item.isCaseMatching,
       matchingPattern: item.matchingPattern, whereClause: expr)
   }

--- a/Sources/AST/Statement/RepeatWhileStatement.swift
+++ b/Sources/AST/Statement/RepeatWhileStatement.swift
@@ -16,17 +16,17 @@
 
 
 public class RepeatWhileStatement : ASTNode, Statement {
-  public private(set) var conditionExpression: Expression
+  public private(set) var conditionExpression: ASTExpression
   public let codeBlock: CodeBlock
 
-  public init(conditionExpression: Expression, codeBlock: CodeBlock) {
+  public init(conditionExpression: ASTExpression, codeBlock: CodeBlock) {
     self.conditionExpression = conditionExpression
     self.codeBlock = codeBlock
   }
 
   // MARK: - Node Mutations
 
-  public func replaceCondition(with expr: Expression) {
+  public func replaceCondition(with expr: ASTExpression) {
     conditionExpression = expr
   }
 

--- a/Sources/AST/Statement/ReturnStatement.swift
+++ b/Sources/AST/Statement/ReturnStatement.swift
@@ -16,15 +16,15 @@
 
 
 public class ReturnStatement : ASTNode, Statement {
-  public private(set) var expression: Expression?
+  public private(set) var expression: ASTExpression?
 
-  public init(expression: Expression? = nil) {
+  public init(expression: ASTExpression? = nil) {
     self.expression = expression
   }
 
   // MARK: - Node Mutations
 
-  public func replaceExpression(with expr: Expression) {
+  public func replaceExpression(with expr: ASTExpression) {
     expression = expr
   }
 

--- a/Sources/AST/Statement/SwitchStatement.swift
+++ b/Sources/AST/Statement/SwitchStatement.swift
@@ -19,9 +19,9 @@ public class SwitchStatement : ASTNode, Statement {
   public enum Case {
     public struct Item {
       public let pattern: Pattern
-      public let whereExpression: Expression?
+      public let whereExpression: ASTExpression?
 
-      public init(pattern: Pattern, whereExpression: Expression? = nil) {
+      public init(pattern: Pattern, whereExpression: ASTExpression? = nil) {
         self.pattern = pattern
         self.whereExpression = whereExpression
       }
@@ -30,17 +30,17 @@ public class SwitchStatement : ASTNode, Statement {
     case `case`([Item], Statements)
     case `default`(Statements)
   }
-  public private(set) var expression: Expression
+  public private(set) var expression: ASTExpression
   public private(set) var cases: [Case]
 
-  public init(expression: Expression, cases: [Case] = []) {
+  public init(expression: ASTExpression, cases: [Case] = []) {
     self.expression = expression
     self.cases = cases
   }
 
   // MARK: - Node Mutations
 
-  public func replaceExpression(with expr: Expression) {
+  public func replaceExpression(with expr: ASTExpression) {
     expression = expr
   }
 

--- a/Sources/AST/Statement/ThrowStatement.swift
+++ b/Sources/AST/Statement/ThrowStatement.swift
@@ -16,15 +16,15 @@
 
 
 public class ThrowStatement : ASTNode, Statement {
-  public private(set) var expression: Expression
+  public private(set) var expression: ASTExpression
 
-  public init(expression: Expression) {
+  public init(expression: ASTExpression) {
     self.expression = expression
   }
 
   // MARK: - Node Mutations
 
-  public func replaceExpression(with expr: Expression) {
+  public func replaceExpression(with expr: ASTExpression) {
     expression = expr
   }
 

--- a/Sources/AST/Version.swift
+++ b/Sources/AST/Version.swift
@@ -18,5 +18,5 @@ public struct Version {
   public let library: String
   public let swift: String
 
-  public static let current = Version(library: "0.19.9", swift: "5.1")
+  public static let current = Version(library: "0.19.10", swift: "5.1")
 }

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -1320,7 +1320,7 @@ extension Parser {
 
   private func parsePatternInitializer() throws -> PatternInitializer {
     let pttrn = try parsePattern()
-    var initExpr: Expression?
+    var initExpr: ASTExpression?
     if _lexer.match(.assignmentOperator) {
       initExpr = try parseExpression()
     }

--- a/Sources/Parser/Parser+Statement.swift
+++ b/Sources/Parser/Parser+Statement.swift
@@ -277,7 +277,7 @@ extension Parser {
     var catchClauses: [DoStatement.CatchClause] = []
     while _lexer.match(.catch) {
       var catchPattern: Pattern?
-      var catchWhere: Expression?
+      var catchWhere: ASTExpression?
       if _lexer.look().kind != .leftBrace {
         if _lexer.look().kind != .where {
           catchPattern = try parsePattern(config: ParserPatternConfig(forPatternMatching: true))
@@ -315,7 +315,7 @@ extension Parser {
         var itemList: [SwitchStatement.Case.Item] = []
         repeat {
           let pattern = try parsePattern(config: forPatternMatchingConfig)
-          var whereExpr: Expression?
+          var whereExpr: ASTExpression?
           if _lexer.match(.where) {
             whereExpr = try parseExpression(config: noTrailingConfig)
           }
@@ -432,7 +432,7 @@ extension Parser {
 
   private func parseCaseCondition(
     config: ParserPatternConfig = ParserPatternConfig()
-  ) throws -> (pattern: Pattern, expression: Expression) {
+  ) throws -> (pattern: Pattern, expression: ASTExpression) {
     var mutableConfig = config
     mutableConfig.parseTrailingClosure = false
     let pattern = try parsePattern(config: mutableConfig)
@@ -504,7 +504,7 @@ extension Parser {
     let matchingPattern = try parsePattern()
     try match(.in, orFatal: .expectedForEachIn)
     let collectionExpr = try parseExpression(config: noTrailingConfig)
-    var whereClause: Expression?
+    var whereClause: ASTExpression?
     if _lexer.match(.where) {
       whereClause = try parseExpression(config: noTrailingConfig)
     }

--- a/Sources/Sema/SequenceExpressionFolding.swift
+++ b/Sources/Sema/SequenceExpressionFolding.swift
@@ -301,7 +301,7 @@ private class FoldingVisitor : ASTVisitor {
       switch eachCase {
       case let .case(items, statements):
         let foldedItems = items.map { i -> SwitchStatement.Case.Item in
-          var foldedWhereExpression: Expression? = i.whereExpression
+          var foldedWhereExpression: ASTExpression? = i.whereExpression
           if let whereSeqExpr = i.whereExpression as? SequenceExpression {
             foldedWhereExpression = foldSequenceExpression(whereSeqExpr)
           }
@@ -709,7 +709,7 @@ private func foldElementsContainSeqExpr(
   }
 }
 
-private func foldSequenceExpression(_ seqExpr: SequenceExpression) -> Expression {
+private func foldSequenceExpression(_ seqExpr: SequenceExpression) -> ASTExpression {
   // Start with brutal hardcoding approach
 
   var resultElements = foldElementsContainSeqExpr(seqExpr.elements)
@@ -741,7 +741,7 @@ private func foldSequenceExpression(_ seqExpr: SequenceExpression) -> Expression
   return resultExpr
 }
 
-private func foldExpression(_ expr: Expression) -> Expression {
+private func foldExpression(_ expr: ASTExpression) -> ASTExpression {
   guard let seqExpr = expr as? SequenceExpression else {
     return expr
   }

--- a/Tests/ASTVisitorTests/DefaultTraverseImplementationTests.swift
+++ b/Tests/ASTVisitorTests/DefaultTraverseImplementationTests.swift
@@ -620,7 +620,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
       rightExpression: WildcardExpression()
     )
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting AssignmentOperatorExpression")
@@ -634,7 +634,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
       rightExpression: WildcardExpression()
     )
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting BinaryOperatorExpression")
@@ -651,7 +651,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
       ]
     )
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting ClosureExpression")
@@ -668,7 +668,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
     ]
     do {
       for node in nodes {
-        let result = try defaultVisitor.traverse(node as Expression)
+        let result = try defaultVisitor.traverse(node as ASTExpression)
         XCTAssertTrue(result)
       }
     } catch {
@@ -679,7 +679,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitForcedValueExpression() {
     let node = ForcedValueExpression(postfixExpression: WildcardExpression())
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting ForcedValueExpression")
@@ -700,7 +700,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
       trailingClosure: ClosureExpression()
     )
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting FunctionCallExpression")
@@ -710,7 +710,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitIdentifierExpression() {
     let node = IdentifierExpression(kind: .identifier(.name("test"), nil))
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting IdentifierExpression")
@@ -720,7 +720,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitImplicitMemberExpression() {
     let node = ImplicitMemberExpression(identifier: .name("test"))
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting ImplicitMemberExpression")
@@ -730,7 +730,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitInOutExpression() {
     let node = InOutExpression(identifier: .name("test"))
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting InOutExpression")
@@ -740,7 +740,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitInitializerExpression() {
     let node = InitializerExpression(postfixExpression: WildcardExpression())
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting InitializerExpression")
@@ -750,7 +750,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitKeyPathStringExpression() {
     let node = KeyPathStringExpression(expression: WildcardExpression())
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting KeyPathStringExpression")
@@ -768,7 +768,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
     ]
     do {
       for node in nodes {
-        let result = try defaultVisitor.traverse(node as Expression)
+        let result = try defaultVisitor.traverse(node as ASTExpression)
         XCTAssertTrue(result)
       }
     } catch {
@@ -779,7 +779,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitOptionalChainingExpression() {
     let node = OptionalChainingExpression(postfixExpression: WildcardExpression())
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting OptionalChainingExpression")
@@ -789,7 +789,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitParenthesizedExpression() {
     let node = ParenthesizedExpression(expression: WildcardExpression())
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting ParenthesizedExpression")
@@ -802,7 +802,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
       postfixExpression: WildcardExpression()
     )
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting PostfixOperatorExpression")
@@ -812,7 +812,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitPostfixSelfExpression() {
     let node = PostfixSelfExpression(postfixExpression: WildcardExpression())
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting PostfixSelfExpression")
@@ -825,7 +825,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
       postfixExpression: WildcardExpression()
     )
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting PrefixOperatorExpression")
@@ -841,7 +841,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
     ]
     do {
       for node in nodes {
-        let result = try defaultVisitor.traverse(node as Expression)
+        let result = try defaultVisitor.traverse(node as ASTExpression)
         XCTAssertTrue(result)
       }
     } catch {
@@ -856,7 +856,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
     ]
     do {
       for node in nodes {
-        let result = try defaultVisitor.traverse(node as Expression)
+        let result = try defaultVisitor.traverse(node as ASTExpression)
         XCTAssertTrue(result)
       }
     } catch {
@@ -870,7 +870,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
       arguments: []
     )
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting SubscriptExpression")
@@ -884,7 +884,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
     ]
     do {
       for node in nodes {
-        let result = try defaultVisitor.traverse(node as Expression)
+        let result = try defaultVisitor.traverse(node as ASTExpression)
         XCTAssertTrue(result)
       }
     } catch {
@@ -899,7 +899,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
       falseExpression: WildcardExpression()
     )
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting TernaryConditionalOperatorExpression")
@@ -914,7 +914,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
     ]
     do {
       for node in nodes {
-        let result = try defaultVisitor.traverse(node as Expression)
+        let result = try defaultVisitor.traverse(node as ASTExpression)
         XCTAssertTrue(result)
       }
     } catch {
@@ -928,7 +928,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
       TupleExpression.Element(identifier: .name("test"), expression: WildcardExpression()),
     ])
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting TupleExpression")
@@ -948,7 +948,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
     ]
     do {
       for node in nodes {
-        let result = try defaultVisitor.traverse(node as Expression)
+        let result = try defaultVisitor.traverse(node as ASTExpression)
         XCTAssertTrue(result)
       }
     } catch {
@@ -959,7 +959,7 @@ class DefaultTraverseImplementationTests : XCTestCase {
   func testVisitWildcardExpression() {
     let node = WildcardExpression()
     do {
-      let result = try defaultVisitor.traverse(node as Expression)
+      let result = try defaultVisitor.traverse(node as ASTExpression)
       XCTAssertTrue(result)
     } catch {
       XCTFail("Failed in visiting WildcardExpression")

--- a/Tests/ParserTests/Expression/Primary/ParserIdentifierExpressionTests.swift
+++ b/Tests/ParserTests/Expression/Primary/ParserIdentifierExpressionTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 class ParserIdentifierExpressionTests: XCTestCase {
   func testNameOnly() {
-    let testClosure: (String, Expression) -> Void = { identifier, expr in
+    let testClosure: (String, ASTExpression) -> Void = { identifier, expr in
       guard let idExpr = expr as? IdentifierExpression,
         case let .identifier(id, generic) = idExpr.kind else {
         XCTFail("Failed in getting an identifier expression")
@@ -41,7 +41,7 @@ class ParserIdentifierExpressionTests: XCTestCase {
   }
 
   func testNameWithGeneric() {
-    let testClosure: (String, String, Expression) -> Void = { identifier, gnrc, expr in
+    let testClosure: (String, String, ASTExpression) -> Void = { identifier, gnrc, expr in
       guard let idExpr = expr as? IdentifierExpression,
         case let .identifier(id, generic) = idExpr.kind else {
         XCTFail("Failed in getting an identifier expression")
@@ -66,7 +66,7 @@ class ParserIdentifierExpressionTests: XCTestCase {
   }
 
   func testImplicitParameter() {
-    let testClosure: (Int, Expression) -> Void = { idx, expr in
+    let testClosure: (Int, ASTExpression) -> Void = { idx, expr in
       guard let idExpr = expr as? IdentifierExpression,
         case let .implicitParameterName(index, generic) = idExpr.kind else {
         XCTFail("Failed in getting an identifier expression")
@@ -84,7 +84,7 @@ class ParserIdentifierExpressionTests: XCTestCase {
   }
 
   func testImplicitParameterWithGeneric() {
-    let testClosure: (Int, Expression) -> Void = { idx, expr in
+    let testClosure: (Int, ASTExpression) -> Void = { idx, expr in
       guard let idExpr = expr as? IdentifierExpression,
         case let .implicitParameterName(index, generic) = idExpr.kind else {
         XCTFail("Failed in getting an identifier expression")
@@ -102,7 +102,7 @@ class ParserIdentifierExpressionTests: XCTestCase {
   }
 
   func testBindingReference() {
-    let testClosure: (String, Expression) -> Void = { identifier, expr in
+    let testClosure: (String, ASTExpression) -> Void = { identifier, expr in
       guard let idExpr = expr as? IdentifierExpression,
         case let .bindingReference(refVar) = idExpr.kind else {
         XCTFail("Failed in getting an identifier expression")

--- a/Tests/ParserTests/Expression/Primary/ParserLiteralExpressionTests.swift
+++ b/Tests/ParserTests/Expression/Primary/ParserLiteralExpressionTests.swift
@@ -129,7 +129,7 @@ class ParserLiteralExpressionTests: XCTestCase {
   func testInterpolatedStringLiteral() { /*
     swift-lint:suppress(high_cyclomatic_complexity,nested_code_block_depth)
     */
-    let testStrings: [(testString: String, expectedExpressions: [Expression])] = [
+    let testStrings: [(testString: String, expectedExpressions: [ASTExpression])] = [
       ( // integer literal
         "\"1 2 \\(3)\"",
         [
@@ -402,7 +402,7 @@ class ParserLiteralExpressionTests: XCTestCase {
       ),
     ]
 
-    func testInterpolatedStringExpressions(exprs: [Expression], expected: [Expression]) { /*
+    func testInterpolatedStringExpressions(exprs: [ASTExpression], expected: [ASTExpression]) { /*
       swift-lint:suppress(high_cyclomatic_complexity)
       */
       // keep this with the minimal code to make the tests pass, and add more handlings when needed

--- a/Tests/ParserTests/Parser+XCTest.swift
+++ b/Tests/ParserTests/Parser+XCTest.swift
@@ -69,7 +69,7 @@ func parseTypeAndTest(_ content: String,
 func parseExpressionAndTest(_ content: String,
   _ expectedTextDescription: String,
   parseTrailingClosure: Bool = true,
-  testClosure: ((Expression) -> Void)? = nil,
+  testClosure: ((ASTExpression) -> Void)? = nil,
   errorClosure: ((Error) -> Void)? = nil) {
   let expressionParser = getParser(content)
 

--- a/Tests/ParserTests/Statement/ParserExpressionStatementTests.swift
+++ b/Tests/ParserTests/Statement/ParserExpressionStatementTests.swift
@@ -25,7 +25,7 @@ class ParserExpressionStatementTests: XCTestCase {
       "(a, _, (b, c)) = (\"test\", 9.45, (12, 3))",
       "(a, _, (b, c)) = (\"test\", 9.45, (12, 3))",
       testClosure: { stmt in
-        XCTAssertTrue(stmt is Expression)
+        XCTAssertTrue(stmt is ASTExpression)
         XCTAssertTrue(stmt is AssignmentOperatorExpression)
       }
     )

--- a/Tests/SemaTests/SequenceExpressionFoldingTests.swift
+++ b/Tests/SemaTests/SequenceExpressionFoldingTests.swift
@@ -390,7 +390,7 @@ class SequenceExpressionFoldingTests: XCTestCase {
   private func semaSeqExprFoldingAndTest(
     _ content: String,
     testFlat: (SequenceExpression) -> Void,
-    testFolded: (Expression) -> Void
+    testFolded: (ASTExpression) -> Void
   ) {
     let topLevelDecl = parse(content)
     XCTAssertFalse(topLevelDecl.sequenceExpressionFolded)
@@ -402,7 +402,7 @@ class SequenceExpressionFoldingTests: XCTestCase {
     let seqExprFolding = SequenceExpressionFolding()
     seqExprFolding.fold([topLevelDecl])
     XCTAssertTrue(topLevelDecl.sequenceExpressionFolded)
-    guard let foldedExpr = topLevelDecl.statements.first as? Expression else {
+    guard let foldedExpr = topLevelDecl.statements.first as? ASTExpression else {
       XCTFail("Failed in folding sequence expression.")
       return
     }


### PR DESCRIPTION
Rename Expression to ASTExpression because failed build with current swift.

Detail open issue #111 

env:
```
swift -v
Apple Swift version 6.1.2 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
Target: arm64-apple-macosx15.0
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-help intro
```